### PR TITLE
baseplot : add_item_with_z_offset : insert item with first choice

### DIFF
--- a/guiqwt/baseplot.py
+++ b/guiqwt/baseplot.py
@@ -497,7 +497,7 @@ class BasePlot(QwtPlot):
         if len(dzlist) == 0:
             z = max(zlist)+1
         else:
-            z = zlist[dzlist]+1
+            z = zlist[dzlist[0]]+1
         self.add_item(item, z=z)
 
     def __clean_item_references(self, item):


### PR DESCRIPTION
If more than one possibility is possible, insert item with first choice. This avoids the following error : TypeError: list indices must be integers, not list