### PR TITLE
104 trimage resize

### DIFF
--- a/guiqwt/image.py
+++ b/guiqwt/image.py
@@ -1509,7 +1509,7 @@ class TrImageItem(RawImageItem):
             dy = zoom * dy
         self.set_transform(x0, y0, angle, dx, dy, hflip, vflip)
         if self.plot():
-            self.plot().SIG_ITEM_MOVED.emit(self, nx, ny, nx, ny)
+            self.plot().SIG_ITEM_MOVED.emit(self, x0, y0, nx, ny)
 
     def move_local_shape(self, old_pos, new_pos):
         """Translate the shape such that old_pos becomes new_pos

--- a/guiqwt/image.py
+++ b/guiqwt/image.py
@@ -1508,6 +1508,8 @@ class TrImageItem(RawImageItem):
             dx = zoom * dx
             dy = zoom * dy
         self.set_transform(x0, y0, angle, dx, dy, hflip, vflip)
+        if self.plot():
+            self.plot().SIG_ITEM_MOVED.emit(self, nx, ny, nx, ny)
 
     def move_local_shape(self, old_pos, new_pos):
         """Translate the shape such that old_pos becomes new_pos


### PR DESCRIPTION
fixes #104 
Used SIG_ITEM_MOVED when TrImageItem resized, not sure if it will make sense in all situations but it solves the problem specified in Issue 104