### PR TITLE
commented out call to QApplication.ProcessEvents() in xcsw_is_visible()

### DIFF
--- a/guiqwt/plot.py
+++ b/guiqwt/plot.py
@@ -823,12 +823,9 @@ class SubplotWidget(QSplitter):
         if height is None:
             height = self.xcsw.height() - self.ycsw.toolbar.height()
         self.ycsw.adjust_height(height)
-        if height:
-            QApplication.processEvents()
-
+        
     def xcsw_is_visible(self, state):
         if state:
-            QApplication.processEvents()
             self.adjust_ycsw_height()
         else:
             self.adjust_ycsw_height(0)
@@ -1294,12 +1291,9 @@ class BaseImageWidget(QSplitter):
         if height is None:
             height = self.xcsw.height() - self.ycsw.toolbar.height()
         self.ycsw.adjust_height(height)
-        if height:
-            QApplication.processEvents()
-
+        
     def xcsw_is_visible(self, state):
         if state:
-            QApplication.processEvents()
             self.adjust_ycsw_height()
         else:
             self.adjust_ycsw_height(0)

--- a/guiqwt/plot.py
+++ b/guiqwt/plot.py
@@ -1301,7 +1301,7 @@ class BaseImageWidget(QSplitter):
 
     def xcsw_is_visible(self, state):
         if state:
-            QApplication.processEvents()
+            #QApplication.processEvents()
             self.adjust_ycsw_height()
         else:
             self.adjust_ycsw_height(0)

--- a/guiqwt/plot.py
+++ b/guiqwt/plot.py
@@ -1245,6 +1245,8 @@ class BaseImageWidget(QSplitter):
         self.xcsw = XCrossSection(self)
         self.xcsw.setVisible(show_xsection)
 
+        self.xcsw.SIG_VISIBILITY_CHANGED.connect(self.xcsw_is_visible)
+
         self.xcsw_splitter = QSplitter(Qt.Vertical, self)
         if xsection_pos == "top":
             self.xcsw_splitter.addWidget(self.xcsw)

--- a/guiqwt/plot.py
+++ b/guiqwt/plot.py
@@ -1248,8 +1248,6 @@ class BaseImageWidget(QSplitter):
         self.xcsw = XCrossSection(self)
         self.xcsw.setVisible(show_xsection)
 
-        self.xcsw.SIG_VISIBILITY_CHANGED.connect(self.xcsw_is_visible)
-
         self.xcsw_splitter = QSplitter(Qt.Vertical, self)
         if xsection_pos == "top":
             self.xcsw_splitter.addWidget(self.xcsw)
@@ -1301,7 +1299,7 @@ class BaseImageWidget(QSplitter):
 
     def xcsw_is_visible(self, state):
         if state:
-            #QApplication.processEvents()
+            QApplication.processEvents()
             self.adjust_ycsw_height()
         else:
             self.adjust_ycsw_height(0)


### PR DESCRIPTION
This is a problem I have had for quite a while and only now getting around to submitting an issue and PR for it.
There are two ways I tested to fix this and both worked and neither caused the plot to behave in a way that did not make sense, 
first is to comment this line

https://github.com/PierreRaybaut/guiqwt/blob/56ae061e128bcf95e489c347a475ea83dc22fb5a/guiqwt/plot.py#L1251

and the second was to instead comment out the call to **ProcessEvents**() in **xcsw_is_visible**, 

https://github.com/PierreRaybaut/guiqwt/blob/56ae061e128bcf95e489c347a475ea83dc22fb5a/guiqwt/plot.py#L1304

I chose the later because it is not ideal to call ProcessEvents directly and it didn't cause the plot to behave strangely.

closes #107 